### PR TITLE
Release 0.3.2

### DIFF
--- a/digits/build.gradle
+++ b/digits/build.gradle
@@ -20,7 +20,7 @@ publishing {
         maven(MavenPublication) {
             groupId = "io.github.dk96-os.decimal-places"
             artifactId = "digits"
-            version = "0.3.1"
+            version = "0.3.2"
             from components.java
         }
     }

--- a/digits/build.gradle
+++ b/digits/build.gradle
@@ -65,11 +65,11 @@ tasks.jacocoTestCoverageVerification {
         rule {
             limit {
                 counter = "INSTRUCTION"
-                minimum = 0.950
+                minimum = 0.960
             }
             limit {
                 counter = "BRANCH"
-                minimum = 0.900
+                minimum = 0.940
             }
         }
     }

--- a/digits/src/main/java/decimalplaces/digits/DigitArray.kt
+++ b/digits/src/main/java/decimalplaces/digits/DigitArray.kt
@@ -69,7 +69,7 @@ class DigitArray(
     fun isLeadDigitOverflowing(
         results: ByteArray = digits,
     ) : Boolean {
-        return results[0] > 9 || results[0] < 0
+        return results.isNotEmpty() && (results[0] > 9 || results[0] < 0)
     }
 
     /** Obtain the Overflow Value from the Lead Digit.

--- a/digits/src/main/java/decimalplaces/digits/DigitArray.kt
+++ b/digits/src/main/java/decimalplaces/digits/DigitArray.kt
@@ -134,8 +134,7 @@ class DigitArray(
 
     /** Remove the Trailing Zeros at the end of the Array.
      */
-    fun trimTrailingZeros()
-        : DigitArray {
+    fun trimTrailingZeros(): DigitArray {
         val initialSize = digits.size - 1
         for (trimIndex in initialSize downTo 1) {
             if (digits[trimIndex] != 0.toByte()) {
@@ -150,12 +149,10 @@ class DigitArray(
 
     /** Remove the Leading Zeros at the start of the Array.
      */
-    fun trimLeadingZeros()
-        : DigitArray {
-        val initialZerothIndex = size - 1
+    fun trimLeadingZeros(): DigitArray {
         for (trimIndex in digits.indices) {
             if (digits[trimIndex] != 0.toByte()) {
-                return if (trimIndex < initialZerothIndex) {
+                return if (trimIndex > 0) {
                     DigitArray(digits.copyOfRange(trimIndex, size))
                 } else
                     this

--- a/digits/src/main/java/decimalplaces/digits/MemoryCompressedDigitArray.kt
+++ b/digits/src/main/java/decimalplaces/digits/MemoryCompressedDigitArray.kt
@@ -25,10 +25,9 @@ class MemoryCompressedDigitArray(
         }
         digits = ByteArray(arraySize) {
             val digitIndex = it * 2
-            val even = digitArray.digits.getOrNull(digitIndex)
-                ?: return@ByteArray 0
             mergeDigits(
-                even, digitArray.digits.getOrNull(digitIndex + 1) ?: 0
+                even = digitArray.digits.getOrElse(digitIndex) { 0 },
+                odd = digitArray.digits.getOrNull(digitIndex + 1) ?: 0
             )
         }
     }
@@ -66,7 +65,7 @@ class MemoryCompressedDigitArray(
             throw IllegalArgumentException("Must set a single Digit non-negative value.")
         }
         if (index < 0 || index >= digitCount)
-            throw IllegalArgumentException("Invalid index: $index")
+            throw IndexOutOfBoundsException("Invalid index: $index")
         val arrayIndex = computeArrayIndex(index)
         val compressedValue = digits[arrayIndex].toInt()
         //

--- a/digits/src/main/java/decimalplaces/digits/MemoryCompressedDigitArray.kt
+++ b/digits/src/main/java/decimalplaces/digits/MemoryCompressedDigitArray.kt
@@ -13,9 +13,9 @@ class MemoryCompressedDigitArray(
      */
     internal val arraySize: Int = computeArraySizeForDigitCount(digitCount)
 
-    /** An array of digit values.
+    /** The array of compressed digit values.
      */
-    internal val digits: ByteArray
+    private val digits: ByteArray
 
     init {
         if (digitArray.isLeadDigitOverflowing()) {
@@ -49,10 +49,7 @@ class MemoryCompressedDigitArray(
     operator fun get(index: Int): Byte? {
         if (index >= digitCount || index < 0)
             return null
-        val arrayIndex = computeArrayIndex(index)
-        if (arrayIndex < 0)
-            return null
-        val compressedDigits = digits.getOrNull(arrayIndex)?.toInt()
+        val compressedDigits = digits.getOrNull(computeArrayIndex(index))?.toInt()
             ?: return null
         return if (index.isEven())
             compressedDigits.ushr(4).toByte()
@@ -97,5 +94,12 @@ class MemoryCompressedDigitArray(
 
     override fun hashCode()
         : Int = digits.contentHashCode()
+
+    /** Expand the DigitArray.
+     * @return A regular DigitArray.
+     */
+    fun expand(): DigitArray {
+        return DigitArray(ByteArray(digitCount) { get(it)!! })
+    }
 
 }

--- a/digits/src/main/java/decimalplaces/digits/MemoryCompressedDigitArray.kt
+++ b/digits/src/main/java/decimalplaces/digits/MemoryCompressedDigitArray.kt
@@ -5,16 +5,11 @@ package decimalplaces.digits
 class MemoryCompressedDigitArray(
     digitArray: DigitArray,
 ) {
-
-    /** A flag indicating whether there is an overflow from the lead digit.
-     */
-    val hasLeadDigitOverflow: Boolean = false
-
     /** The Number of Digits.
      */
     val digitCount: Int = digitArray.size
 
-    /** The Size of the Array.
+    /** The Size of the Array. At least half of the digit count.
      */
     val arraySize: Int = computeArraySizeForDigitCount(digitCount)
 
@@ -27,7 +22,6 @@ class MemoryCompressedDigitArray(
             throw IllegalArgumentException(
                 "Remove Lead Digit Overflow Before Compressing DigitArray."
             )
-            //todo: Transfer Lead Digit Overflow Into Compressed DigitArray
         }
         digits = ByteArray(arraySize) {
             val digitIndex = it * 2
@@ -56,150 +50,32 @@ class MemoryCompressedDigitArray(
     }
 
     operator fun get(index: Int): Byte? {
-        require(index in 0..< digitCount)
-        val arrayIndex = computeArrayIndex(index)
-        val compressedByte = digits.getOrNull(arrayIndex) ?: return null
+        val compressedDigits = digits.getOrNull(computeArrayIndex(index))?.toInt()
+            ?: return null
         return if (index.isEven())
-            compressedByte.toInt().ushr(4).toByte()
+            compressedDigits.ushr(4).toByte()
         else
-            compressedByte.toInt().shl(28).ushr(28).toByte()
+            compressedDigits.shl(28).ushr(28).toByte()
     }
 
-    override fun toString()
-        : String = digits.joinToString("")
+    override fun toString(): String {
+        val builder = StringBuilder()
+        for (compressedDigit in digits) {
+            val integer = compressedDigit.toInt()
+            builder.append(integer.shr(4))
+            if (digitCount.isEven()) continue
+            builder.append(integer.shl(28).shr(28))
+        }
+        return builder.toString()
+    }
 
     override fun equals(other: Any?): Boolean {
         if (other !is MemoryCompressedDigitArray) return false
-        return this.hasLeadDigitOverflow == other.hasLeadDigitOverflow &&
+        return this.digitCount == other.digitCount &&
                 this.digits.contentEquals(other.digits)
     }
 
     override fun hashCode()
         : Int = digits.contentHashCode()
-
-    operator fun plus(other: MemoryCompressedDigitArray): MemoryCompressedDigitArray {
-        val newSize = maxOf(digits.size, other.digits.size)
-        val result = if (digits.size > other.digits.size)
-            ByteArray(newSize) {
-                if (it < other.digits.size) (digits[it] + other.digits[it]).toByte()
-                else digits[it]
-            }
-        else if (digits.size == other.digits.size)
-            ByteArray(newSize) {
-                (digits[it] + other.digits[it]).toByte()
-            }
-        else
-            ByteArray(newSize) {
-                if (it < digits.size) (digits[it] + other.digits[it]).toByte()
-                else other.digits[it]
-            }
-        for (i in newSize - 1 downTo 1) {
-            val digitValue = result[i]
-            if (digitValue > 9) {
-                result[i - 1] = (result[i - 1] + digitValue / 10).toByte()
-                result[i] = (digitValue % 10).toByte()
-            }
-        }
-        return MemoryCompressedDigitArray(DigitArray(result))
-    }
-
-    fun isLeadDigitOverflowing(
-        results: ByteArray = digits,
-    ) : Boolean {
-        if (hasLeadDigitOverflow) return true
-        return results[0] > 9 || results[0] < 0
-    }
-
-    /** Obtain the Overflow Value from the Lead Digit.
-     */
-    fun collectOverflowFromLeadDigit(
-        results: ByteArray = digits,
-    ) : Byte {
-        val leadDigit = results[0]
-        if (leadDigit < 0) { // Lead Digit is Negative
-            results[0] = (10 - ((leadDigit * -1) % 10)).toByte()
-            return ((leadDigit) / 10).toByte()
-        }
-        results[0] = (leadDigit % 10).toByte()
-        return (leadDigit / 10).toByte()
-    }
-
-    operator fun minus(other: MemoryCompressedDigitArray): MemoryCompressedDigitArray {
-        val result = ByteArray(maxOf(digits.size, other.digits.size)) {
-            if (it < digits.size) digits[it] else 0
-        }
-        for (i in result.size - 1 downTo 0) {
-            val otherDigitValue = if (i < other.digits.size) other.digits[i] else 0
-            if (otherDigitValue < 0 || otherDigitValue > 9)
-                throw IllegalArgumentException("Other DigitArray contains non-normalized digits.")
-            if (otherDigitValue == 0.toByte())
-                continue
-            val diff = result[i] - otherDigitValue
-            result[i] = (if (diff < 0) {
-                val borrowIndex = findBorrowableIndex(i - 1, result)
-                if (-1 < borrowIndex) {
-                    result[borrowIndex] = result[borrowIndex].dec()
-                    for (j in borrowIndex + 1 until i)
-                        result[j] = 9
-                    10 + diff
-                } else if (i == 0) diff - 10 else {
-                    // Negative Lead Digit Overflow
-                    result[0] = (-11).toByte()
-                    for (j in 1 until i)
-                        result[j] = 9
-                    10 + diff
-                }
-            } else diff).toByte()
-        }
-        return MemoryCompressedDigitArray(DigitArray(result))
-    }
-
-    /** Find an index that can be borrowed from.
-     *  Returns the largest index below the start index where the value is greater than zero.
-     *  @param startIndex The first index in the search. This index will be checked first.
-     *  @param digitArray The Array of Digits.
-     *  @return The index of the first digit that can be borrowed from, given the start index.
-     */
-    fun findBorrowableIndex(
-        startIndex: Int,
-        digitArray: ByteArray = digits,
-    ) : Int {
-        for (i in startIndex downTo  0) {
-            if (digitArray[i] > 0) return i // Can be borrowed from
-        }
-        return -1
-    }
-
-    /** Remove the Trailing Zeros at the end of the Array.
-     */
-    fun trimTrailingZeros()
-        : MemoryCompressedDigitArray {
-        val initialSize = digits.size - 1
-        for (trimIndex in initialSize downTo 1) {
-            if (digits[trimIndex] != 0.toByte()) {
-                return if (trimIndex < initialSize) {
-                    MemoryCompressedDigitArray(DigitArray(digits.copyOf(trimIndex + 1)))
-                } else
-                    this
-            }
-        }
-        return MemoryCompressedDigitArray(DigitArray(byteArrayOf(0)))
-    }
-
-    /** Remove the Leading Zeros at the start of the Array.
-     */
-    fun trimLeadingZeros()
-        : MemoryCompressedDigitArray {
-        val initialZerothIndex = arraySize - 1
-        for (trimIndex in digits.indices) {
-            if (digits[trimIndex] != 0.toByte()) {
-                return if (trimIndex < initialZerothIndex) {
-                    MemoryCompressedDigitArray(DigitArray(digits.copyOfRange(trimIndex, arraySize)))
-                } else
-                    this
-            }
-        }
-        return MemoryCompressedDigitArray(DigitArray(byteArrayOf(0)))
-    }
 
 }

--- a/digits/src/main/java/decimalplaces/digits/MemoryCompressedDigitArray.kt
+++ b/digits/src/main/java/decimalplaces/digits/MemoryCompressedDigitArray.kt
@@ -1,0 +1,160 @@
+package decimalplaces.digits
+
+/** Manages an Array of Digits.
+ */
+class MemoryCompressedDigitArray(
+    /** A bit used by the Lead Digit, especially after a subtraction operation.
+     */
+    val leadDigitBit: Boolean = false,
+    /** An array of digit values.
+     */
+    val digits: ByteArray,
+) {
+    /** The Size of the Array.
+     */
+    val size: Int = digits.size
+
+    operator fun get(index: Int): Byte {
+        require(index >= 0 && index < digits.size)
+        digits
+        return digits[index]
+    }
+
+    override fun toString()
+        : String = digits.joinToString("")
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is MemoryCompressedDigitArray) return false
+        return this.leadDigitBit == other.leadDigitBit &&
+                this.digits.contentEquals(other.digits)
+    }
+
+    override fun hashCode()
+        : Int = digits.contentHashCode()
+
+    operator fun plus(other: MemoryCompressedDigitArray): MemoryCompressedDigitArray {
+        val newSize = maxOf(digits.size, other.digits.size)
+        val result = if (digits.size > other.digits.size)
+            ByteArray(newSize) {
+                if (it < other.digits.size) (digits[it] + other.digits[it]).toByte()
+                else digits[it]
+            }
+        else if (digits.size == other.digits.size)
+            ByteArray(newSize) {
+                (digits[it] + other.digits[it]).toByte()
+            }
+        else
+            ByteArray(newSize) {
+                if (it < digits.size) (digits[it] + other.digits[it]).toByte()
+                else other.digits[it]
+            }
+        for (i in newSize - 1 downTo 1) {
+            val digitValue = result[i]
+            if (digitValue > 9) {
+                result[i - 1] = (result[i - 1] + digitValue / 10).toByte()
+                result[i] = (digitValue % 10).toByte()
+            }
+        }
+        return MemoryCompressedDigitArray(result)
+    }
+
+    fun isLeadDigitOverflowing(
+        results: ByteArray = digits,
+    ) : Boolean {
+        if (leadDigitBit) return true
+        return results[0] > 9 || results[0] < 0
+    }
+
+    /** Obtain the Overflow Value from the Lead Digit.
+     */
+    fun collectOverflowFromLeadDigit(
+        results: ByteArray = digits,
+    ) : Byte {
+        val leadDigit = results[0]
+        if (leadDigit < 0) { // Lead Digit is Negative
+            results[0] = (10 - ((leadDigit * -1) % 10)).toByte()
+            return ((leadDigit) / 10).toByte()
+        }
+        results[0] = (leadDigit % 10).toByte()
+        return (leadDigit / 10).toByte()
+    }
+
+    operator fun minus(other: MemoryCompressedDigitArray): MemoryCompressedDigitArray {
+        val result = ByteArray(maxOf(digits.size, other.digits.size)) {
+            if (it < digits.size) digits[it] else 0
+        }
+        for (i in result.size - 1 downTo 0) {
+            val otherDigitValue = if (i < other.digits.size) other.digits[i] else 0
+            if (otherDigitValue < 0 || otherDigitValue > 9)
+                throw IllegalArgumentException("Other DigitArray contains non-normalized digits.")
+            if (otherDigitValue == 0.toByte())
+                continue
+            val diff = result[i] - otherDigitValue
+            result[i] = (if (diff < 0) {
+                val borrowIndex = findBorrowableIndex(i - 1, result)
+                if (-1 < borrowIndex) {
+                    result[borrowIndex] = result[borrowIndex].dec()
+                    for (j in borrowIndex + 1 until i)
+                        result[j] = 9
+                    10 + diff
+                } else if (i == 0) diff - 10 else {
+                    // Negative Lead Digit Overflow
+                    result[0] = (-11).toByte()
+                    for (j in 1 until i)
+                        result[j] = 9
+                    10 + diff
+                }
+            } else diff).toByte()
+        }
+        return MemoryCompressedDigitArray(result)
+    }
+
+    /** Find an index that can be borrowed from.
+     *  Returns the largest index below the start index where the value is greater than zero.
+     *  @param startIndex The first index in the search. This index will be checked first.
+     *  @param digitArray The Array of Digits.
+     *  @return The index of the first digit that can be borrowed from, given the start index.
+     */
+    fun findBorrowableIndex(
+        startIndex: Int,
+        digitArray: ByteArray = digits,
+    ) : Int {
+        for (i in startIndex downTo  0) {
+            if (digitArray[i] > 0) return i // Can be borrowed from
+        }
+        return -1
+    }
+
+    /** Remove the Trailing Zeros at the end of the Array.
+     */
+    fun trimTrailingZeros()
+        : MemoryCompressedDigitArray {
+        val initialSize = digits.size - 1
+        for (trimIndex in initialSize downTo 1) {
+            if (digits[trimIndex] != 0.toByte()) {
+                return if (trimIndex < initialSize) {
+                    MemoryCompressedDigitArray(digits.copyOf(trimIndex + 1))
+                } else
+                    this
+            }
+        }
+        return MemoryCompressedDigitArray(byteArrayOf(0))
+    }
+
+    /** Remove the Leading Zeros at the start of the Array.
+     */
+    fun trimLeadingZeros()
+        : MemoryCompressedDigitArray {
+        val initialZerothIndex = size - 1
+        for (trimIndex in digits.indices) {
+            if (digits[trimIndex] != 0.toByte()) {
+                return if (trimIndex < initialZerothIndex) {
+                    MemoryCompressedDigitArray(digits.copyOfRange(trimIndex, size))
+                } else
+                    this
+            }
+        }
+        return MemoryCompressedDigitArray(byteArrayOf(0))
+    }
+
+}

--- a/digits/src/test/java/decimalplaces/digits/DigitArrayTest.kt
+++ b/digits/src/test/java/decimalplaces/digits/DigitArrayTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
-class TestDigitArray {
+class DigitArrayTest {
 
     private lateinit var mInstance: DigitArray
 

--- a/digits/src/test/java/decimalplaces/digits/DigitArrayTest.kt
+++ b/digits/src/test/java/decimalplaces/digits/DigitArrayTest.kt
@@ -20,6 +20,13 @@ class DigitArrayTest {
     }
 
     @Test
+    fun testDigitCount_InitialCondition_Returns3() {
+        assertEquals(
+            3, mInstance.digitCount
+        )
+    }
+    
+    @Test
     fun accessDigits() {
         assertEquals(mInstance[0], 3.toByte())
         assertEquals(mInstance[1], 9.toByte())
@@ -34,12 +41,12 @@ class DigitArrayTest {
     }
 
     @Test
-    fun equals_InitialCondition_Self_ReturnsTrue() {
+    fun testEquals_InitialCondition_Self_ReturnsTrue() {
         assertEquals(mInstance, mInstance)
     }
 
     @Test
-    fun equals_InitialCondition_SameValues_ReturnsTrue() {
+    fun testEquals_InitialCondition_SameValues_ReturnsTrue() {
         assertEquals(
             DigitArray(byteArrayOf(3, 9, 4)),
             mInstance
@@ -47,7 +54,7 @@ class DigitArrayTest {
     }
 
     @Test
-    fun equals_InitialCondition_DifferentValue1_ReturnsFalse() {
+    fun testEquals_InitialCondition_DifferentValue1_ReturnsFalse() {
         assertNotEquals(
             DigitArray(byteArrayOf(2, 9, 4)),
             mInstance
@@ -55,10 +62,17 @@ class DigitArrayTest {
     }
 
     @Test
-    fun equals_InitialCondition_DifferentValue2_ReturnsFalse() {
+    fun testEquals_InitialCondition_DifferentValue2_ReturnsFalse() {
         assertNotEquals(
             DigitArray(byteArrayOf(3, 7, 4)),
             mInstance
+        )
+    }
+
+    @Test
+    fun testEquals_InitialCondition_String_ReturnsFalse() {
+        assertFalse(
+            mInstance.equals(394)
         )
     }
 
@@ -418,7 +432,14 @@ class DigitArrayTest {
     }
 
     @Test
-    fun trimTrailingZeros_() {
+    fun testTrimTrailingZeros_InitialCondition_ReturnsUnchanged() {
+        assertEquals(
+            mInstance, mInstance.trimTrailingZeros()
+        )
+    }
+
+    @Test
+    fun testTrimTrailingZeros_() {
         mInstance = DigitArray(byteArrayOf(1, 0))
         mInstance = mInstance.trimTrailingZeros()
         assertEquals(
@@ -427,7 +448,7 @@ class DigitArrayTest {
     }
 
     @Test
-    fun trimTrailingZeros_2() {
+    fun testTrimTrailingZeros_2() {
         mInstance = DigitArray(byteArrayOf(1, 0, 2, 0))
         mInstance = mInstance.trimTrailingZeros()
         assertEquals(
@@ -439,7 +460,7 @@ class DigitArrayTest {
     }
 
     @Test
-    fun trimTrailingZeros_AllZero3() {
+    fun testTrimTrailingZeros_AllZero3() {
         mInstance = DigitArray(byteArrayOf(0, 0, 0))
         mInstance = mInstance.trimTrailingZeros()
         assertEquals(
@@ -449,7 +470,14 @@ class DigitArrayTest {
     }
 
     @Test
-    fun trimLeadingZeros_() {
+    fun testTrimLeadingZeros_InitialCondition_ReturnsUnchanged() {
+        assertEquals(
+            mInstance, mInstance.trimLeadingZeros()
+        )
+    }
+
+    @Test
+    fun testTrimLeadingZeros_() {
         mInstance = DigitArray(byteArrayOf(1, 0))
         mInstance = mInstance.trimLeadingZeros()
         assertEquals(
@@ -458,7 +486,7 @@ class DigitArrayTest {
     }
 
     @Test
-    fun trimLeadingZeros_2() {
+    fun testTrimLeadingZeros_2() {
         mInstance = DigitArray(byteArrayOf(0, 1, 2, 0))
         mInstance = mInstance.trimLeadingZeros()
         assertEquals(
@@ -470,7 +498,7 @@ class DigitArrayTest {
     }
 
     @Test
-    fun trimLeadingZeros_AllZero3() {
+    fun testTrimLeadingZeros_AllZero3_ReturnsSingleZero() {
         mInstance = DigitArray(byteArrayOf(0, 0, 0))
         mInstance = mInstance.trimLeadingZeros()
         assertEquals(
@@ -524,6 +552,15 @@ class DigitArrayTest {
         val result = DigitArray.fromString(maxLongString)
         assertEquals(
             maxLongString, result.toString()
+        )
+    }
+
+    @Test
+    fun testFromString_IncludesAlphabetCharacters_ReturnsFilteredNumbers() {
+        val input = "hello123world456"
+        val result = DigitArray.fromString(input)
+        assertEquals(
+            "123456", result.toString()
         )
     }
 

--- a/digits/src/test/java/decimalplaces/digits/MemoryCompressedDigitArrayTest.kt
+++ b/digits/src/test/java/decimalplaces/digits/MemoryCompressedDigitArrayTest.kt
@@ -1,0 +1,121 @@
+package decimalplaces.digits
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class MemoryCompressedDigitArrayTest {
+
+
+    private lateinit var regularDigitArray: DigitArray
+    private lateinit var mInstance: MemoryCompressedDigitArray
+
+    @BeforeEach
+    fun testSetup() {
+        regularDigitArray = DigitArray(byteArrayOf(4, 6, 2))
+        mInstance = MemoryCompressedDigitArray(regularDigitArray)
+    }
+
+    private fun setupAlternative() {
+        regularDigitArray = DigitArray(byteArrayOf(1, 2, 3, 4))
+        mInstance = MemoryCompressedDigitArray(regularDigitArray)
+    }
+
+    @Test
+    fun testArraySize_InitialCondition_Returns2() {
+        assertEquals(
+            2, mInstance.arraySize
+        )
+        // Regular Digit Array
+        assertEquals(
+            3, regularDigitArray.digits.size
+        )
+    }
+
+    @Test
+    fun testArraySize_Alternative_Returns2() {
+        setupAlternative()
+        assertEquals(
+            2, mInstance.arraySize
+        )
+        assertEquals(
+            4, regularDigitArray.digits.size
+        )
+    }
+
+    @Test
+    fun testDigitCount_InitialCondition_Returns3() {
+        assertEquals(
+            3, mInstance.digitCount
+        )
+        // Regular Digit Array Size
+        assertEquals(
+            3, regularDigitArray.digits.size
+        )
+    }
+
+    @Test
+    fun testDigitCount_Alternative_Returns4() {
+        setupAlternative()
+        assertEquals(
+            4, mInstance.digitCount
+        )
+        // Regular Digit Array Size
+        assertEquals(
+            4, regularDigitArray.digits.size
+        )
+    }
+
+    @Test
+    fun testGet_InitialCondition_ReturnsDigits() {
+        assertEquals(
+            4, mInstance[0]
+        )
+        assertEquals(
+            6, mInstance[1]
+        )
+        assertEquals(
+            2, mInstance[2]
+        )
+    }
+
+    @Test
+    fun testGet_InitialCondition_OutOfBounds_ReturnsNull() {
+        assertNull(mInstance[3])
+    }
+
+    @Test
+    fun testGet_InitialCondition_NegativeIndex_ReturnsEndOfArrayIndex() {
+        assertNull(mInstance[-1])
+        assertNull(mInstance[-2])
+    }
+
+    @Test
+    fun testGet_Alternative_NegativeIndex_ReturnsArrayIndex() {
+        regularDigitArray = DigitArray(byteArrayOf(1, 2, 3, 4))
+        mInstance = MemoryCompressedDigitArray(regularDigitArray)
+        assertNull(mInstance[-1])
+        assertNull(mInstance[-2])
+        assertNull(mInstance[-3])
+    }
+
+    @Test
+    fun testToString_InitialCondition_SameAsRegularDigitArray() {
+        assertEquals(
+            regularDigitArray.toString(),
+            mInstance.toString()
+        )
+    }
+
+    @Test
+    fun testToString_Alternative_SameAsRegularDigitArray() {
+        regularDigitArray = DigitArray(byteArrayOf(1, 2, 3, 4))
+        mInstance = MemoryCompressedDigitArray(regularDigitArray)
+        assertEquals(
+            regularDigitArray.toString(),
+            mInstance.toString()
+        )
+    }
+
+}

--- a/digits/src/test/java/decimalplaces/digits/MemoryCompressedDigitArrayTest.kt
+++ b/digits/src/test/java/decimalplaces/digits/MemoryCompressedDigitArrayTest.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.assertThrows
 
 class MemoryCompressedDigitArrayTest {
 
-
     private lateinit var regularDigitArray: DigitArray
     private lateinit var mInstance: MemoryCompressedDigitArray
 
@@ -43,6 +42,15 @@ class MemoryCompressedDigitArrayTest {
         )
         assertEquals(
             4, regularDigitArray.digits.size
+        )
+    }
+
+    @Test
+    fun testArraySize_EmptyArray_ReturnsZero() {
+        val emptyDigitArray = DigitArray(byteArrayOf())
+        val emptyCompressedDigitArray = MemoryCompressedDigitArray(emptyDigitArray)
+        assertEquals(
+            0, emptyCompressedDigitArray.arraySize
         )
     }
 
@@ -143,6 +151,14 @@ class MemoryCompressedDigitArrayTest {
     }
 
     @Test
+    fun testSet_Index2_Value1() {
+        mInstance[2] = 1
+        assertEquals(
+            "461", mInstance.toString()
+        )
+    }
+
+    @Test
     fun testToString_InitialCondition_SameAsRegularDigitArray() {
         assertEquals(
             regularDigitArray.toString(),
@@ -200,6 +216,30 @@ class MemoryCompressedDigitArrayTest {
     fun testHashCode_InitialCondition_ReturnsStable() {
         assertEquals(
             3163, mInstance.hashCode()
+        )
+    }
+
+    @Test
+    fun testExpand_InitialCondition_ReturnsRegularDigitArray() {
+        assertEquals(
+            regularDigitArray, mInstance.expand()
+        )
+    }
+
+    @Test
+    fun testExpand_Alternative_ReturnsRegularDigitArray() {
+        setupAlternative()
+        assertEquals(
+            regularDigitArray, mInstance.expand()
+        )
+    }
+
+    @Test
+    fun testExpand_EmptyArray_ReturnsEmpty() {
+        regularDigitArray = DigitArray(byteArrayOf())
+        mInstance = MemoryCompressedDigitArray(regularDigitArray)
+        assertEquals(
+            regularDigitArray, mInstance.expand()
         )
     }
 

--- a/digits/src/test/java/decimalplaces/digits/MemoryCompressedDigitArrayTest.kt
+++ b/digits/src/test/java/decimalplaces/digits/MemoryCompressedDigitArrayTest.kt
@@ -1,9 +1,11 @@
 package decimalplaces.digits
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class MemoryCompressedDigitArrayTest {
 
@@ -101,6 +103,46 @@ class MemoryCompressedDigitArrayTest {
     }
 
     @Test
+    fun testSet_Index0_Value0_UpdatesDigits() {
+        mInstance[0] = 0
+        assertEquals("062", mInstance.toString())
+    }
+
+    @Test
+    fun testSet_Index1_Value0_UpdatesDigits() {
+        mInstance[1] = 0
+        assertEquals("402", mInstance.toString())
+    }
+
+    @Test
+    fun testSet_NegativeIndex_ThrowsIndexOutOfBoundsException() {
+        assertThrows<IndexOutOfBoundsException> {
+            mInstance[-1] = 5
+        }
+    }
+
+    @Test
+    fun testSet_IndexOutOfBounds_ThrowsIndexOutOfBoundsException() {
+        assertThrows<IndexOutOfBoundsException> {
+            mInstance[10] = 5
+        }
+    }
+
+    @Test
+    fun testSet_Index0_NegativeValue_ThrowsIllegalArgumentsException() {
+        assertThrows<IllegalArgumentException> {
+            mInstance[0] = -1
+        }
+    }
+
+    @Test
+    fun testSet_Index0_LargeValue_ThrowsIllegalArgumentsException() {
+        assertThrows<IllegalArgumentException> {
+            mInstance[0] = 20
+        }
+    }
+
+    @Test
     fun testToString_InitialCondition_SameAsRegularDigitArray() {
         assertEquals(
             regularDigitArray.toString(),
@@ -115,6 +157,49 @@ class MemoryCompressedDigitArrayTest {
         assertEquals(
             regularDigitArray.toString(),
             mInstance.toString()
+        )
+    }
+
+    @Test
+    fun testConstructor_LeadDigitOverflow_ThrowsIllegalArgumentException() {
+        val overflowingDigitArray = regularDigitArray + DigitArray(byteArrayOf(9, 9, 9))
+        assertThrows<IllegalArgumentException> {
+            MemoryCompressedDigitArray(overflowingDigitArray)
+        }
+    }
+
+    @Test
+    fun testEquals_InitialCondition_SameDigitArray_ReturnsFalse() {
+        assertNotEquals(mInstance, regularDigitArray)
+    }
+
+    @Test
+    fun testEquals_InitialCondition_SimilarMemoryCompressedDigitArray_ReturnsTrue() {
+        assertEquals(
+            mInstance, MemoryCompressedDigitArray(regularDigitArray)
+        )
+    }
+
+    @Test
+    fun testEquals_InitialCondition_DifferentDigitCount_ReturnsTrue() {
+        regularDigitArray = DigitArray(byteArrayOf(5, 4, 3, 2, 1))
+        assertNotEquals(
+            mInstance, MemoryCompressedDigitArray(regularDigitArray)
+        )
+    }
+
+    @Test
+    fun testEquals_InitialCondition_DifferentDigitValue_ReturnsFalse() {
+        regularDigitArray.digits[1] = 0
+        assertNotEquals(
+            mInstance, MemoryCompressedDigitArray(regularDigitArray)
+        )
+    }
+
+    @Test
+    fun testHashCode_InitialCondition_ReturnsStable() {
+        assertEquals(
+            3163, mInstance.hashCode()
         )
     }
 


### PR DESCRIPTION
Introducing `MemoryCompressedDigitArray`, an independent class using basic techniques to reduce Memory usage of the DigitArray.

## Problem Statement

The current `DigitArray` implementation allocates about twice as many bits as are necessary to represent each digit.

### Why This Is Sub-Optimal

It is important to keep a handle on memory usage, especially at the smallest data structure level. Any application that uses DigitArray will likely wrap it in some other data structure and create abstractions around that.

### Additional Considerations

The complexity of `DigitArray` could quickly increase if not managed. Other features are planned for development, and it would be best to limit any near-future development friction that may be imposed by this memory compression feature.

## When to Use

1. You want to save memory
  - You have a large `DigitArray`
  - You have many `DigitArray` instances
  - You have a `DigitArray` that will live in memory for a while
2. You only need Get/Set and toString/Equals/HashCode methods

### How To Use

1. Call the constructor, passing a `DigitArray` argument.
2. Discard your regular `DigitArray` reference.
3. Use the `MemoryCompressedDigitArray` reference.

### Public Methods and Technical Usage Notes

- The `MemoryCompressedDigitArray` constructor requires a `DigitArray` instance.
- Implements Get/Set indexing operators for Read/Write access to individual digits
- Implements toString, hashCode, and Equals methods
- Provides the number of Digits via `digitCount`

## Key Benefits

- Half the Array Size (Memory usage) of regular `DigitArray`
- Distinct Definition

## Initial Feature and Branch Setup

This PR uses a new feature branch (`feature-memory`) and tracks it. The initial implementation is based on the provided code for `MemoryCompressedDigitArray`. Further development will focus on refining this class while maintaining compatibility with the existing `DigitArray` class.