### PR TITLE
Release 0.3.1

### DIFF
--- a/digits/build.gradle
+++ b/digits/build.gradle
@@ -65,11 +65,11 @@ tasks.jacocoTestCoverageVerification {
         rule {
             limit {
                 counter = "INSTRUCTION"
-                minimum = 0.940
+                minimum = 0.950
             }
             limit {
                 counter = "BRANCH"
-                minimum = 0.850
+                minimum = 0.900
             }
         }
     }

--- a/digits/src/main/java/decimalplaces/digits/DigitArray.kt
+++ b/digits/src/main/java/decimalplaces/digits/DigitArray.kt
@@ -11,9 +11,22 @@ class DigitArray(
      */
     val size: Int = digits.size
 
-    operator fun get(index: Int): Byte {
-        require(index >= 0 && index < digits.size)
-        return digits[index]
+    /** The number of Digits.
+     */
+    val digitCount: Int = size
+
+    operator fun get(index: Int): Byte? {
+        return digits.getOrNull(index)
+    }
+
+    operator fun set(index: Int, value: Byte) {
+        if (index < 0 || index >= digitCount)
+            throw IndexOutOfBoundsException()
+        if (value < 0 || value > 9)
+            throw IllegalArgumentException(
+                "The Value must be a single digit non-negative number."
+            )
+        digits[index] = value
     }
 
     override fun toString()
@@ -149,6 +162,36 @@ class DigitArray(
             }
         }
         return DigitArray(byteArrayOf(0))
+    }
+
+    companion object {
+        /** Construct a Digit Array from an Integer.
+         * Note that integers cannot produce DigitArrays with leading zeros.
+         * @param integer The Integer to be translated into a DigitArray.
+         * @return The DigitArray containing the base 10 digits of the Integer.
+         */
+        fun fromInteger(integer: Int): DigitArray {
+            val numberString = integer.toString()
+            return DigitArray(ByteArray(numberString.length) {
+                // 48 is the code for 0, and 49 is the code for 1.
+                numberString[it].code.minus(48).toByte()
+            })
+        }
+
+        /** Construct a Digit Array from a String.
+         * Filters all characters not within the digit range.
+         * @param value The String to be translated into a DigitArray.
+         * @return The DigitArray containing the base 10 digits of the Integer.
+         */
+        fun fromString(value: String): DigitArray {
+            val numberString = value.chars()
+                .map { (it - 48) }
+                .filter { it > -1 && it < 10 }
+                .toArray()
+            return DigitArray(ByteArray(numberString.size) {
+                numberString[it].toByte()
+            })
+        }
     }
 
 }

--- a/digits/src/test/java/decimalplaces/digits/DigitArrayTest.kt
+++ b/digits/src/test/java/decimalplaces/digits/DigitArrayTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class TestDigitArray {
 
@@ -59,6 +60,46 @@ class TestDigitArray {
             DigitArray(byteArrayOf(3, 7, 4)),
             mInstance
         )
+    }
+
+    @Test
+    fun testSet_Index0_Value0_UpdatesDigits() {
+        mInstance[0] = 0
+        assertEquals("094", mInstance.toString())
+    }
+
+    @Test
+    fun testSet_Index1_Value0_UpdatesDigits() {
+        mInstance[1] = 0
+        assertEquals("304", mInstance.toString())
+    }
+
+    @Test
+    fun testSet_NegativeIndex_Value0_UpdatesDigits() {
+        assertThrows<IndexOutOfBoundsException> {
+            mInstance[-1] = 5
+        }
+    }
+
+    @Test
+    fun testSet_IndexOutOfBounds_ThrowsIndexOutOfBoundsException() {
+        assertThrows<IndexOutOfBoundsException> {
+            mInstance[10] = 5
+        }
+    }
+
+    @Test
+    fun testSet_Index0_NegativeValue_ThrowsIllegalArgumentsException() {
+        assertThrows<IllegalArgumentException> {
+            mInstance[0] = -1
+        }
+    }
+
+    @Test
+    fun testSet_Index0_LargeValue_ThrowsIllegalArgumentsException() {
+        assertThrows<IllegalArgumentException> {
+            mInstance[0] = 20
+        }
     }
 
     @Test
@@ -483,6 +524,13 @@ class TestDigitArray {
         val result = DigitArray.fromString(maxLongString)
         assertEquals(
             maxLongString, result.toString()
+        )
+    }
+
+    @Test
+    fun testHashCode_InitialCondition_ReturnsStable() {
+        assertEquals(
+            32957, mInstance.hashCode()
         )
     }
 

--- a/digits/src/test/java/decimalplaces/digits/DigitArrayTest.kt
+++ b/digits/src/test/java/decimalplaces/digits/DigitArrayTest.kt
@@ -438,4 +438,52 @@ class TestDigitArray {
         assertEquals(0, mInstance.digits[0])
     }
 
+    @Test
+    fun testFromInteger_SameAs_InitialCondition_IsEqual() {
+        assertEquals(
+            mInstance, DigitArray.fromInteger(394)
+        )
+    }
+
+    @Test
+    fun testFromInteger_0_ReturnsSingleDigitArray() {
+        val result = DigitArray.fromInteger(0)
+        assertEquals(1, result.size)
+        assertEquals("0", result.toString())
+    }
+
+
+    @Test
+    fun testFromInteger_MaxValue_ReturnsMaxValueDigitArray() {
+        val result = DigitArray.fromInteger(Integer.MAX_VALUE)
+        assertEquals(10, result.size)
+        assertEquals(
+            Integer.MAX_VALUE.toString(),
+            result.toString()
+        )
+    }
+
+    @Test
+    fun testFromString_SameAs_InitialCondition_IsEqual() {
+        assertEquals(
+            mInstance, DigitArray.fromString("394")
+        )
+    }
+
+    @Test
+    fun testFromString_0_ReturnsSameAsFromInteger0() {
+        assertEquals(
+            DigitArray.fromInteger(0), DigitArray.fromString("0")
+        )
+    }
+
+    @Test
+    fun testFromString_MaxLongValue_ReturnsMaxLong() {
+        val maxLongString = Long.MAX_VALUE.toString()
+        val result = DigitArray.fromString(maxLongString)
+        assertEquals(
+            maxLongString, result.toString()
+        )
+    }
+
 }


### PR DESCRIPTION
Improve the overall Quality of DigitArray.

### More ways to create a DigitArray
- [x] Add static method for creating new DigitArray from an Integer
- [x] Add static method creating new DigitArray from a String

### Indexing Operator Conveniences
Indexing operators are written using the square bracket notation. For example, `array[1]`.
The `Set` operator is used when assigning to an index, otherwise the `Get` method is used.
- [x] Implement `Set` operator method
- [x] `Get` operator method returns null when index is invalid

### More Meaningful Names for Properties
- [x] Add `digitCount` property to offer a more expressive name than the `size` property